### PR TITLE
add array transfer benchmark to confirm data transfer makes 0.3.0 slower

### DIFF
--- a/bench-0.1/src/test/scala/SlincBenchmark.scala
+++ b/bench-0.1/src/test/scala/SlincBenchmark.scala
@@ -5,6 +5,15 @@ import java.util.concurrent.TimeUnit
 import org.openjdk.jmh.infra.Blackhole
 import fr.hammons.slinc.Ptr
 
+
+@State(Scope.Thread)
+class TransferArrayState {
+  var values: Array[Int] = null
+  @Setup
+  def setup(): Unit =
+    values = Array.fill(1_000)(scala.util.Random.nextInt())
+}
+
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -30,6 +39,11 @@ class NativeBenchmarks {
   def ctimeSlinc: String = ctimeSlincBenchHelper.run
   @Benchmark
   def ctimeJNI: String = jniInstance.run()
+  
+  @Benchmark
+  def transferArray(bh: Blackhole, state: TransferArrayState): Array[Int] =
+    ctimeSlincBenchHelper.transferArray(state.values)
+  
 }
 
 @State(Scope.Thread)

--- a/bench-0.3/src/test/scala/SlincBenchmark.scala
+++ b/bench-0.3/src/test/scala/SlincBenchmark.scala
@@ -6,6 +6,14 @@ import org.openjdk.jmh.infra.Blackhole
 import fr.hammons.slinc.Ptr
 import fr.hammons.slinc.fset.FSetBacking
 
+@State(Scope.Thread)
+class TransferArrayState {
+  var values: Array[Int] = null
+  @Setup
+  def setup(): Unit =
+    values = Array.fill(1_000)(scala.util.Random.nextInt())
+}
+
 @State(Scope.Benchmark)
 @BenchmarkMode(Array(Mode.AverageTime))
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -33,6 +41,10 @@ class NativeBenchmarks {
   def ctimeSlinc: String = ctimeSlincBenchHelper.run(slincInst)
   @Benchmark
   def ctimeJNI: String = jniInstance.run()
+
+  @Benchmark
+  def transferArray(bh: Blackhole, state: TransferArrayState): Array[Int] =
+    ctimeSlincBenchHelper.transferArray(state.values)
 }
 
 @State(Scope.Thread)

--- a/core-0.1/src/main/scala/benchSlinc.scala
+++ b/core-0.1/src/main/scala/benchSlinc.scala
@@ -15,6 +15,11 @@ object benchBinding derives Library:
   ): Unit = Library.binding
 
 object ctimeSlincBenchHelper:
+  def transferArray(arr: Array[Int]): Array[Int] =
+    Scope.confined {
+      val data = Ptr.copy(arr)
+      data.asArray(arr.length).unsafeArray
+    }
   def runQsortWithoutCopyBack(
       arr: Array[Int],
       cb: Ptr[(Ptr[Any], Ptr[Any]) => Int]

--- a/core-0.3/src/main/scala/benchSlinc.scala
+++ b/core-0.3/src/main/scala/benchSlinc.scala
@@ -16,6 +16,13 @@ trait benchBinding derives FSet:
   ): Unit
 
 object ctimeSlincBenchHelper:
+  def transferArray(
+      arr: Array[Int]
+  ): Array[Int] =
+    Scope.confined {
+      val data = Ptr.copy(arr)
+      data.asArray(arr.length).unsafeArray
+    }
   val ELM_SIZE = sizeOf[Int]
   def runQsortWithoutCopyBack(
       benchBinding: benchBindingType,
@@ -31,6 +38,7 @@ object ctimeSlincBenchHelper:
         cb
       )
     }
+
   def runQsortAllocCallbackForEachIteration(
       benchBinding: benchBindingType,
       arr: Array[Int]


### PR DESCRIPTION
Added a simpler benchmark to test whether array transfer makes 0.3.0 slower.


0.1.1: transferArray  719.305 ±     17.468  ns/op
0.3.0: transferArray   8757.059 ±   172.298  ns/op

0.1.1

`bench01/jmh:run`

```
[info] Benchmark                                                           Mode  Cnt        Score        Error  Units
[info] NativeBenchmarks.ctimeJNI                                           avgt    5     5061.988 ±    264.100  ns/op
[info] NativeBenchmarks.ctimeSlinc                                         avgt    5     5804.605 ±    119.846  ns/op
[info] NativeBenchmarks.transferArray                                      avgt    5      719.305 ±     17.468  ns/op
[info] SimpleNativeCallBenchmarks.jniNativeQSort                           avgt    5     4093.743 ±     71.879  ns/op
[info] SimpleNativeCallBenchmarks.jniQSort                                 avgt    5   284165.693 ±   6417.593  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortJVM                            avgt    5      188.441 ±      1.321  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortWithCopyBack                   avgt    5   590090.535 ±  11654.453  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortWithoutCopyBack                avgt    5   600580.965 ±  20396.423  ns/op
[info] SimpleNativeCallBenchmarks.slincQsortAllocCallbackForEachIteration  avgt    5  1576361.275 ± 433246.358  ns/op
```

0.3.0

`bench03/jmh:run`


```
[info] Benchmark                                                           Mode  Cnt        Score       Error  Units
[info] NativeBenchmarks.ctimeJNI                                           avgt    5     5207.719 ±   526.507  ns/op
[info] NativeBenchmarks.ctimeSlinc                                         avgt    5     6982.084 ±   449.125  ns/op
[info] NativeBenchmarks.transferArray                                      avgt    5     8757.059 ±   172.298  ns/op
[info] SimpleNativeCallBenchmarks.jniNativeQSort                           avgt    5     4072.950 ±    44.364  ns/op
[info] SimpleNativeCallBenchmarks.jniQSort                                 avgt    5   286298.198 ±  1536.418  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortJVM                            avgt    5      188.509 ±     1.722  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortWithCopyBack                   avgt    5   988247.007 ± 20414.582  ns/op
[info] SimpleNativeCallBenchmarks.slincQSortWithoutCopyBack                avgt    5   974531.008 ± 18471.669  ns/op
[info] SimpleNativeCallBenchmarks.slincQsortAllocCallbackForEachIteration  avgt    5  1700098.296 ± 54528.982  ns/op
```

NOTE: Strangely, SimpleNativeCallBenchmarks.slincQSortWithCopyBack   sometimes get much slower than SimpleNativeCallBenchmarks.slincQSortWithoutCopyBack , but it is not always the case.